### PR TITLE
Merge Tabular data update row branch into master

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,9 +4,12 @@
 
 Bamboozled wraps the [BambooHR API](http://www.bamboohr.com/api/documentation/) without the use of Rails dependencies. Currently, this gem is **READ-ONLY**.
 
-# Usage:
+# Preliminary notes:
+We use a fork of this gem https://github.com/Skookum/bamboozled. The fork was originally in former employee's repo kylefdoherty/bamboozled and then we forked his fork after he left. To add to this complication, we have been using a specific branch of this fork called `tabular_data_update_row`. As of July 2018 no one knows why this branched was made and not merged into master but we have decided to merge this branch into our master fork to eliminate some of the confusion around Pistachio not using the master branch of the fork of the fork. Note however that the master in our fork may have diverged quite a bit from the original master. Additionally it is possible that the original gem now includes some of the functionality that we added in our fork; however, we have not had time to investigate or implement this as of yet.
 
-Install the gem with `gem install bamboozled` or add this to your `Gemfile`: `gem 'bamboozled'`
+# Usage:
+Add this to your `Gemfile`: `gem 'bamboozled', git: "https://github.com/alphasights/bamboozled.git"`
+You can also specify a branch and reference which is useful for devlopment. ie `gem 'bamboozled', git: "https://github.com/alphasights/bamboozled.git", branch: "tabular_data_update_row", ref: 'e3129f8'`
 
 ```ruby
 # Create the client:
@@ -82,6 +85,9 @@ client.meta.tables
 # Note: this is all uses in the system, whereas client.employee.all only gets active employees
 client.meta.users
 ```
+
+## Logging / Debugging
+If you ever need to log the requests being made to bamboo you can look to the now removed https://github.com/alphasights/bamboozled/pull/1/ for reference. Bamboo support, which is nearly worthless, will often request you send them the raw http requests being made.
 
 ## Todo:
 

--- a/lib/bamboozled.rb
+++ b/lib/bamboozled.rb
@@ -8,7 +8,9 @@ require_relative './bamboozled/version'
 require_relative './bamboozled/errors'
 require_relative './bamboozled/base'
 
-%w(base employee report time_off meta).each {|a| require_relative "./bamboozled/api/#{a}"}
+%w(base employee report time_off meta tabular).each do |a|
+  require_relative "./bamboozled/api/#{a}"
+end
 
 module Bamboozled
   class << self

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -38,7 +38,12 @@ module Bamboozled
               if response.body.to_s.empty?
                 {"headers" => response.headers, "code" => "200", "message" => "ok"}.with_indifferent_access
               else
-                JSON.parse(response.body).with_indifferent_access
+                json = JSON.parse(response.body)
+                if json.is_a?(Array)
+                  JSON.parse(response.body).map(&:with_indifferent_access)
+                else
+                  JSON.parse(response.body).with_indifferent_access
+                end
               end
             rescue
               MultiXml.parse(response, symbolize_keys: true)

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -22,6 +22,7 @@ module Bamboozled
             query:  options[:query],
             body:   options[:body],
             format: :plain,
+            ssl_version: :TLSv1_2,
             basic_auth: auth,
             headers: {
               "Accept"       => "application/json",

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -36,7 +36,7 @@ module Bamboozled
           when 200..201
             begin
               if response.body.to_s.empty?
-                {"headers" => response.headers}.with_indifferent_access
+                {"headers" => response.headers, "code" => "200", "message" => "ok"}.with_indifferent_access
               else
                 JSON.parse(response.body).with_indifferent_access
               end

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -18,11 +18,15 @@ module Bamboozled
             method:  method
           }
 
+          strio = StringIO.new
+          log = Logger.new strio
+
           httparty_options = {
             query:  options[:query],
             body:   options[:body],
             format: :plain,
             ssl_version: :TLSv1_2,
+            debug_output: log,
             basic_auth: auth,
             headers: {
               "Accept"       => "application/json",
@@ -36,6 +40,33 @@ module Bamboozled
           case response.code
           when 200..201
             begin
+              if ENV.fetch('BAMBOO_REQUEST_LOGGING_ENBALED', false) == "true"
+                encoded_auth_to_remove = Base64.encode64("#{auth[:username]}:#{auth[:password]}").chomp
+
+                employee_number_match = /(employeeNumber\D*)(\d*)/.match(httparty_options[:body])
+                employee_number = employee_number_match[2].presence if employee_number_match.present?
+
+                work_email_match = /([a-zA-Z\.]*@alphasights.com)/.match(httparty_options[:body])
+                work_email = work_email_match[1].presence if work_email_match.present?
+
+                bamboo_id_match = /(employees\/)(\d*)/.match(path)
+                bamboo_id = bamboo_id_match[2].presence if bamboo_id_match.present?
+
+                request_log = method.to_s == "get" ? nil : strio.string.gsub(encoded_auth_to_remove, "REDACTED-AUTH")
+
+                BambooRequestLog.create(
+                  response_headers: response.headers.to_json,
+                  response_timestamp: response["date"],
+                  request_method: method.to_s,
+                  request_path: "#{path_prefix}#{path}",
+                  request_body: httparty_options[:body],
+                  raw_httparty_request_log: request_log,
+                  involving_employee_number:  employee_number,
+                  involving_work_email: work_email,
+                  involving_bamboo_id: bamboo_id
+                )
+              end
+
               if response.body.to_s.empty?
                 {"headers" => response.headers, "code" => "200", "message" => "ok"}.with_indifferent_access
               else

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -61,6 +61,13 @@ module Bamboozled
         request(:post, "employees/", options)
       end
 
+      def update(bamboo_id:, employee_details:)
+        details = generate_xml(employee_details)
+        options = {body: details}
+
+        request(:post, "employees/#{bamboo_id}", options)
+      end
+
       private
 
       def generate_xml(employee_details)

--- a/lib/bamboozled/api/tabular.rb
+++ b/lib/bamboozled/api/tabular.rb
@@ -1,9 +1,16 @@
 module Bamboozled
   module API
     class Tabular < Base
-      require "pry"
       def add_row(table_name: nil, details: nil, employee_id: nil)
         url = "employees/#{employee_id}/tables/#{table_name}"
+        row_data = generate_xml(details)
+        options = { body: row_data }
+
+        request(:post, url, options)
+      end
+
+      def update_row(table_name: nil, details: nil, employee_id: nil, row_id: nil)
+        url = "employees/#{employee_id}/tables/#{table_name}/#{row_id}"
         row_data = generate_xml(details)
         options = { body: row_data }
 

--- a/lib/bamboozled/api/tabular.rb
+++ b/lib/bamboozled/api/tabular.rb
@@ -10,6 +10,12 @@ module Bamboozled
         request(:post, url, options)
       end
 
+      def get_table(table_name: nil, employee_id: nil)
+        url = "employees/#{employee_id}/tables/#{table_name}"
+
+        request(:get, url)
+      end
+
       private
 
       def generate_xml(details)

--- a/lib/bamboozled/api/tabular.rb
+++ b/lib/bamboozled/api/tabular.rb
@@ -1,0 +1,24 @@
+module Bamboozled
+  module API
+    class Tabular < Base
+      require "pry"
+      def add_row(table_name: nil, details: nil, employee_id: nil)
+        url = "employees/#{employee_id}/tables/#{table_name}"
+        row_data = generate_xml(details)
+        options = { body: row_data }
+
+        request(:post, url, options)
+      end
+
+      private
+
+      def generate_xml(details)
+        "".tap do |xml|
+          xml << "<row>"
+          details.each { |k, v| xml << "<field id='#{k}'>#{v}</field>" }
+          xml << "</row>"
+        end
+      end
+    end
+  end
+end

--- a/lib/bamboozled/base.rb
+++ b/lib/bamboozled/base.rb
@@ -21,5 +21,9 @@ module Bamboozled
     def time_off
       @time_off ||= Bamboozled::API::TimeOff.new(@subdomain, @api_key)
     end
+
+    def tabular
+      @tabular ||= Bamboozled::API::Tabular.new(@subdomain, @api_key)
+    end
   end
 end

--- a/spec/fixtures/add_row_details.json
+++ b/spec/fixtures/add_row_details.json
@@ -1,0 +1,8 @@
+{
+  "date": "2015-08-04",
+  "location": "New York",
+  "division": "North America",
+  "department": "Software Engineering",
+  "jobTitle": "Apprentice",
+  "reportsTo": "John Johnson"
+}

--- a/spec/fixtures/add_row_response.json
+++ b/spec/fixtures/add_row_response.json
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+date: Tue, 17 Jun 2014 19:25:35 UTC

--- a/spec/fixtures/add_row_xml.yml
+++ b/spec/fixtures/add_row_xml.yml
@@ -1,0 +1,9 @@
+body:
+  <row><field id='date'>2015-08-04</field><field id='location'>New York</field><field id='division'>North America</field><field id='department'>Software Engineering</field><field id='jobTitle'>Apprentice</field><field id='reportsTo'>John Johnson</field></row>
+headers:
+  Accept:
+  - application/json
+  User-Agent:
+  - Bamboozled/0.0.7
+
+

--- a/spec/fixtures/update_employee_details.json
+++ b/spec/fixtures/update_employee_details.json
@@ -1,0 +1,7 @@
+{
+  "firstName": "Bruce",
+  "lastName": "Wayne",
+  "workEmail": "b.wayne@gmail.com",
+  "jobTitle": "Batman",
+  "city": "Gotham"
+}

--- a/spec/fixtures/update_employee_response.json
+++ b/spec/fixtures/update_employee_response.json
@@ -1,4 +1,3 @@
 HTTP/1.1 200 OK
 content-type: application/json; charset=utf-8
 date: Tue, 17 Jun 2014 19:25:35 UTC
-location: https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259

--- a/spec/fixtures/update_employee_xml.yml
+++ b/spec/fixtures/update_employee_xml.yml
@@ -1,0 +1,8 @@
+body:
+  <employee><field id='firstName'>Bruce</field><field id='lastName'>Wayne</field><field id='workEmail'>b.wayne@gmail.com</field><field id='jobTitle'>Batman</field><field id='city'>Gotham</field></employee>
+headers:
+  Accept:
+  - application/json
+  User-Agent:
+  - Bamboozled/0.0.7
+

--- a/spec/lib/bamboozled/employee_spec.rb
+++ b/spec/lib/bamboozled/employee_spec.rb
@@ -117,6 +117,22 @@ describe "Employees" do
     end
   end
 
+  describe "#update" do
+    it 'updates an employee in BambooHR' do
+      xml = YAML.load_file('spec/fixtures/update_employee_xml.yml')
+      response = File.new('spec/fixtures/update_employee_response.json')
+      details = JSON.parse(File.read('spec/fixtures/update_employee_details.json'))
+
+      stub_request(:post, "https://x:x@api.bamboohr.com/api/gateway.php/x/v1/employees/1234").
+        with(xml).to_return(response)
+
+      employee = @client.employee.update(bamboo_id: '1234', employee_details: details)
+
+      employee["headers"].
+        must_equal({"content-type"=>["application/json; charset=utf-8"], "date"=>["Tue, 17 Jun 2014 19:25:35 UTC"]})
+    end
+  end
+
   # TODO - Figure out how to test this with webmock
   # it 'returns binary data for an employee photo' do
   # end

--- a/spec/lib/bamboozled/tabular_spec.rb
+++ b/spec/lib/bamboozled/tabular_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../spec_helper'
+require 'pry'
+
+describe "Employees" do
+
+  before do
+    @client = Bamboozled.client(subdomain:'x', api_key:'x')
+  end
+
+  describe "#add_position" do
+    it "adds a position row to the specified table in BambooHR" do
+      xml = YAML.load_file('spec/fixtures/add_row_xml.yml')
+      response = File.new('spec/fixtures/add_row_response.json')
+      details = JSON.parse(File.read('spec/fixtures/add_row_details.json'))
+
+      stub_request(:post, /.*api\.bamboohr\.com.*/).with(xml).to_return(response)
+
+      response = @client.tabular.add_row(table_name: "jobInfo", details: details, employee_id: 12345)
+
+      expect(response["code"]).to eq("200")
+    end
+  end
+end

--- a/spec/lib/bamboozled/tabular_spec.rb
+++ b/spec/lib/bamboozled/tabular_spec.rb
@@ -1,5 +1,4 @@
 require_relative '../../spec_helper'
-require 'pry'
 
 describe "Employees" do
 


### PR DESCRIPTION
For a while we have been using the `tabular_data_update_row` as the ref point for the gem in pistachio. No one left knows why we never merged this into master but for the sake of clarity we are doing so now. 

Note that our master may be a bit different from the original gem's master. See readme changes for more https://github.com/alphasights/bamboozled/commit/2a86efc7261b4c89135a8dcf26ecda72d22e6cc0

### After merge

- [ ] Update pistachio to reference this fork's master as the gem source instead of `gem 'bamboozled', git: "https://github.com/alphasights/bamboozled.git", branch: "tabular_data_update_row", ref: 'e3129f8'`